### PR TITLE
Remove ability to update namespace state from tctl command

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -118,7 +118,6 @@ var (
 	FlagDescriptionAlias              = []string{"desc"}
 	FlagOwnerEmail                    = "owner-email"
 	FlagOwnerEmailAlias               = []string{"oe"}
-	FlagState                         = "state"
 	FlagRetention                     = "retention"
 	FlagRetentionAlias                = []string{"rd"}
 	FlagHistoryArchivalState          = "history-archival-state"

--- a/cli/namespaceCommands.go
+++ b/cli/namespaceCommands.go
@@ -35,7 +35,6 @@ import (
 	replicationpb "go.temporal.io/api/replication/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
-
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
@@ -185,7 +184,6 @@ func UpdateNamespace(c *cli.Context) error {
 		description := resp.NamespaceInfo.GetDescription()
 		ownerEmail := resp.NamespaceInfo.GetOwnerEmail()
 		retention := timestamp.DurationValue(resp.Config.GetWorkflowExecutionRetentionTtl())
-		state := enumspb.NAMESPACE_STATE_UNSPECIFIED
 		var clusters []*replicationpb.ClusterReplicationConfig
 
 		if c.IsSet(FlagDescription) {
@@ -193,14 +191,6 @@ func UpdateNamespace(c *cli.Context) error {
 		}
 		if c.IsSet(FlagOwnerEmail) {
 			ownerEmail = c.String(FlagOwnerEmail)
-		}
-		if c.IsSet(FlagState) {
-			stateStr := c.String(FlagState)
-			if stateInt, ok := enumspb.NamespaceState_value[stateStr]; !ok {
-				return fmt.Errorf("unknown namespace state: %s. Supported states: [Registered, Deprecated, Deleted, Handover].", stateStr)
-			} else {
-				state = enumspb.NamespaceState(stateInt)
-			}
 		}
 		namespaceData := map[string]string{}
 		if c.IsSet(FlagNamespaceData) {
@@ -255,7 +245,6 @@ func UpdateNamespace(c *cli.Context) error {
 			Description: description,
 			OwnerEmail:  ownerEmail,
 			Data:        namespaceData,
-			State:       state,
 		}
 
 		archState, err := archivalState(c, FlagHistoryArchivalState)

--- a/cli/namespaceUtils.go
+++ b/cli/namespaceUtils.go
@@ -125,10 +125,6 @@ var (
 			Usage:   "Owner email",
 		},
 		&cli.StringFlag{
-			Name:  FlagState,
-			Usage: "Namespace state",
-		},
-		&cli.StringFlag{
 			Name:    FlagRetention,
 			Aliases: FlagRetentionAlias,
 			Usage:   "Workflow execution retention",

--- a/cli_curr/flags.go
+++ b/cli_curr/flags.go
@@ -129,7 +129,6 @@ const (
 	FlagDescriptionWithAlias                  = FlagDescription + ", desc"
 	FlagOwnerEmail                            = "owner_email"
 	FlagOwnerEmailWithAlias                   = FlagOwnerEmail + ", oe"
-	FlagState                                 = "state"
 	FlagRetention                             = "retention"
 	FlagRetentionWithAlias                    = FlagRetention + ", rd"
 	FlagHistoryArchivalState                  = "history_archival_state"

--- a/cli_curr/namespaceCommands.go
+++ b/cli_curr/namespaceCommands.go
@@ -200,7 +200,6 @@ func (d *namespaceCLIImpl) UpdateNamespace(c *cli.Context) {
 		description := resp.NamespaceInfo.GetDescription()
 		ownerEmail := resp.NamespaceInfo.GetOwnerEmail()
 		retention := timestamp.DurationValue(resp.Config.GetWorkflowExecutionRetentionTtl())
-		state := enumspb.NAMESPACE_STATE_UNSPECIFIED
 		var clusters []*replicationpb.ClusterReplicationConfig
 
 		if c.IsSet(FlagDescription) {
@@ -208,14 +207,6 @@ func (d *namespaceCLIImpl) UpdateNamespace(c *cli.Context) {
 		}
 		if c.IsSet(FlagOwnerEmail) {
 			ownerEmail = c.String(FlagOwnerEmail)
-		}
-		if c.IsSet(FlagState) {
-			stateStr := c.String(FlagState)
-			if stateInt, ok := enumspb.NamespaceState_value[stateStr]; !ok {
-				ErrorAndExit(fmt.Sprintf("Unknown namespace state: %s. Supported states: [Registered, Deprecated, Deleted, Handover].", stateStr), nil)
-			} else {
-				state = enumspb.NamespaceState(stateInt)
-			}
 		}
 		namespaceData := map[string]string{}
 		if c.IsSet(FlagNamespaceData) {
@@ -270,7 +261,6 @@ func (d *namespaceCLIImpl) UpdateNamespace(c *cli.Context) {
 			Description: description,
 			OwnerEmail:  ownerEmail,
 			Data:        namespaceData,
-			State:       state,
 		}
 		updateConfig := &namespacepb.NamespaceConfig{
 			WorkflowExecutionRetentionTtl: &retention,

--- a/cli_curr/namespaceUtils.go
+++ b/cli_curr/namespaceUtils.go
@@ -112,10 +112,6 @@ var (
 			Usage: "Owner email",
 		},
 		cli.StringFlag{
-			Name:  FlagState,
-			Usage: "Namespace state",
-		},
-		cli.StringFlag{
 			Name:  FlagRetentionWithAlias,
 			Usage: "Workflow execution retention",
 		},


### PR DESCRIPTION
Namespace state update need more steps and should be handled by a workflow. 
Update the state metadata would be just one step of the workflow.
We should create other command for tctl to trigger operations like DeleteNamespace.